### PR TITLE
Fix incorrect string literal in ReadContractSymbol

### DIFF
--- a/golang/client/onchain/onchain.go
+++ b/golang/client/onchain/onchain.go
@@ -191,7 +191,7 @@ func ReadContractSymbol(client *ethclient.Client, contractAddress common.Address
 
 	// Unpack the result
 	var contractName string
-	err = parsedABI.UnpackIntoInterface(&contractName, "name", result)
+	err = parsedABI.UnpackIntoInterface(&contractName, "symbol", result)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Bug: `ReadContractSymbol` calls the `name` view function (not the `symbol` view function). Fixed.