### PR TITLE
Swagger/struct generation now uses concrete types exclusively to simplify config object setup

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -84,7 +84,7 @@ func main() {
 			Dst:             tokens.PolygonWeth,
 			From:            os.Getenv("WALLET_ADDRESS"),
 			Amount:          amounts.Ten16,
-			DisableEstimate: helpers.GetPtr(true),
+			DisableEstimate: true,
 			Slippage:        0.5,
 		},
 	}

--- a/golang/client/orderbook/helpers.go
+++ b/golang/client/orderbook/helpers.go
@@ -1,6 +1,0 @@
-package orderbook
-
-// GetSortByParameter is a helper function that returns the pointer of the currency type being used
-func GetSortByParameter(currency LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortBy) *LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortBy {
-	return &currency
-}

--- a/golang/client/orderbook/orderbook_types.gen.go
+++ b/golang/client/orderbook/orderbook_types.gen.go
@@ -24,10 +24,10 @@ const (
 // LimitOrderV3Data defines model for LimitOrderV3Data.
 type LimitOrderV3Data struct {
 	// AllowedSender An address of the wallet or contract who will be able to fill this order (equals to Zero address on public orders)
-	AllowedSender *string `json:"allowedSender,omitempty"`
+	AllowedSender string `json:"allowedSender,omitempty"`
 
 	// Interactions Merged offsets of each field in interactions
-	Interactions *string `json:"interactions,omitempty"`
+	Interactions string `json:"interactions,omitempty"`
 
 	// Maker An address of the maker (wallet or contract address)
 	Maker string `json:"maker"`
@@ -39,10 +39,10 @@ type LimitOrderV3Data struct {
 	MakingAmount string `json:"makingAmount"`
 
 	// Offsets An interaction call data. ABI encoded set of makerAssetData, takerAssetData, getMakingAmount, getTakingAmount, predicate, permit, preInteraction, postInteraction
-	Offsets *string `json:"offsets,omitempty"`
+	Offsets string `json:"offsets,omitempty"`
 
 	// Receiver An address of the wallet or contract who will receive filled amount (equals to Zero address for receiver == makerAddress)
-	Receiver *string `json:"receiver,omitempty"`
+	Receiver string `json:"receiver,omitempty"`
 
 	// Salt Some unique value. It is necessary to be able to create limit orders with the same parameters (so that they have a different hash)
 	Salt string `json:"salt"`
@@ -69,20 +69,20 @@ type LimitOrderV3Request struct {
 // LimitOrderV3SubscribedApiControllerGetLimitOrderParams defines parameters for LimitOrderV3SubscribedApiControllerGetLimitOrder.
 type LimitOrderV3SubscribedApiControllerGetLimitOrderParams struct {
 	// Page Pagination step, default: 1 (page = offset / limit)
-	Page *float32 `url:"page,omitempty" json:"page,omitempty"`
+	Page float32 `url:"page,omitempty" json:"page,omitempty"`
 
 	// Limit Number of limit orders to receive (default: 100, max: 500)
-	Limit *float32 `url:"limit,omitempty" json:"limit,omitempty"`
+	Limit float32 `url:"limit,omitempty" json:"limit,omitempty"`
 
 	// Statuses JSON an array of statuses by which limit orders will be filtered: 1 - valid limit orders, 2 - temporary invalid limit orders, 3 - invalid limit orders
-	Statuses *[]float32                                                    `url:"statuses,omitempty" json:"statuses,omitempty"`
-	SortBy   *LimitOrderV3SubscribedApiControllerGetLimitOrderParamsSortBy `url:"sortBy,omitempty" json:"sortBy,omitempty"`
+	Statuses []float32                                                    `url:"statuses,omitempty" json:"statuses,omitempty"`
+	SortBy   LimitOrderV3SubscribedApiControllerGetLimitOrderParamsSortBy `url:"sortBy,omitempty" json:"sortBy,omitempty"`
 
 	// TakerAsset Address of the taker asset
-	TakerAsset *string `url:"takerAsset,omitempty" json:"takerAsset,omitempty"`
+	TakerAsset string `url:"takerAsset,omitempty" json:"takerAsset,omitempty"`
 
 	// MakerAsset Address of the maker asset
-	MakerAsset *string `url:"makerAsset,omitempty" json:"makerAsset,omitempty"`
+	MakerAsset string `url:"makerAsset,omitempty" json:"makerAsset,omitempty"`
 }
 
 // LimitOrderV3SubscribedApiControllerGetLimitOrderParamsSortBy defines parameters for LimitOrderV3SubscribedApiControllerGetLimitOrder.
@@ -91,20 +91,20 @@ type LimitOrderV3SubscribedApiControllerGetLimitOrderParamsSortBy string
 // LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams defines parameters for LimitOrderV3SubscribedApiControllerGetAllLimitOrders.
 type LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams struct {
 	// Page Pagination step, default: 1 (page = offset / limit)
-	Page *float32 `url:"page,omitempty" json:"page,omitempty"`
+	Page float32 `url:"page,omitempty" json:"page,omitempty"`
 
 	// Limit Number of limit orders to receive (default: 100, max: 500)
-	Limit *float32 `url:"limit,omitempty" json:"limit,omitempty"`
+	Limit float32 `url:"limit,omitempty" json:"limit,omitempty"`
 
 	// Statuses JSON an array of statuses by which limit orders will be filtered: 1 - valid limit orders, 2 - temporary invalid limit orders, 3 - invalid limit orders
-	Statuses *[]float32                                                        `url:"statuses,omitempty" json:"statuses,omitempty"`
-	SortBy   *LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortBy `url:"sortBy,omitempty" json:"sortBy,omitempty"`
+	Statuses []float32                                                        `url:"statuses,omitempty" json:"statuses,omitempty"`
+	SortBy   LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortBy `url:"sortBy,omitempty" json:"sortBy,omitempty"`
 
 	// TakerAsset Address of the maker asset
-	TakerAsset *string `url:"takerAsset,omitempty" json:"takerAsset,omitempty"`
+	TakerAsset string `url:"takerAsset,omitempty" json:"takerAsset,omitempty"`
 
 	// MakerAsset Address of the maker asset
-	MakerAsset *string `url:"makerAsset,omitempty" json:"makerAsset,omitempty"`
+	MakerAsset string `url:"makerAsset,omitempty" json:"makerAsset,omitempty"`
 }
 
 // LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortBy defines parameters for LimitOrderV3SubscribedApiControllerGetAllLimitOrders.

--- a/golang/client/orderbook/orderbook_types.go
+++ b/golang/client/orderbook/orderbook_types.go
@@ -16,14 +16,14 @@ type CreateOrderParams struct {
 
 func (params *CreateOrderParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.WalletKey, "walletKey", validate.CheckPrivateKey, validationErrors)
-	validationErrors = validate.Parameter(params.SourceWallet, "sourceWallet", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.FromToken, "fromToken", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.ToToken, "toToken", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.TakingAmount, "takingAmount", validate.CheckBigInt, validationErrors)
-	validationErrors = validate.Parameter(params.MakingAmount, "makingAmount", validate.CheckBigInt, validationErrors)
-	validationErrors = validate.Parameter(params.Receiver, "receiver", validate.CheckEthereumAddress, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.WalletKey, "walletKey", validate.CheckPrivateKeyRequired, validationErrors)
+	validationErrors = validate.Parameter(params.SourceWallet, "sourceWallet", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.FromToken, "fromToken", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.ToToken, "toToken", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.TakingAmount, "takingAmount", validate.CheckBigIntRequired, validationErrors)
+	validationErrors = validate.Parameter(params.MakingAmount, "makingAmount", validate.CheckBigIntRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Receiver, "receiver", validate.CheckEthereumAddressRequired, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
 
@@ -35,14 +35,14 @@ type GetOrdersByCreatorAddressParams struct {
 
 func (params *GetOrdersByCreatorAddressParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.CreatorAddress, "creatorAddress", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Page, "page", validate.CheckPagePointer, validationErrors)
-	validationErrors = validate.Parameter(params.Limit, "limit", validate.CheckLimitPointer, validationErrors)
-	validationErrors = validate.Parameter(params.Statuses, "statuses", validate.CheckStatusesIntsPointer, validationErrors)
-	validationErrors = validate.Parameter((*string)(params.SortBy), "sortBy", validate.CheckSortByPointer, validationErrors)
-	validationErrors = validate.Parameter(params.TakerAsset, "takerAsset", validate.CheckEthereumAddressPointer, validationErrors)
-	validationErrors = validate.Parameter(params.MakerAsset, "makerAsset", validate.CheckEthereumAddressPointer, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.CreatorAddress, "creatorAddress", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Page, "page", validate.CheckPage, validationErrors)
+	validationErrors = validate.Parameter(params.Limit, "limit", validate.CheckLimit, validationErrors)
+	validationErrors = validate.Parameter(params.Statuses, "statuses", validate.CheckStatusesInts, validationErrors)
+	validationErrors = validate.Parameter((string)(params.SortBy), "sortBy", validate.CheckSortBy, validationErrors)
+	validationErrors = validate.Parameter(params.TakerAsset, "takerAsset", validate.CheckEthereumAddress, validationErrors)
+	validationErrors = validate.Parameter(params.MakerAsset, "makerAsset", validate.CheckEthereumAddress, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
 
@@ -53,13 +53,13 @@ type GetAllOrdersParams struct {
 
 func (params *GetAllOrdersParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.Page, "page", validate.CheckPagePointer, validationErrors)
-	validationErrors = validate.Parameter(params.Limit, "limit", validate.CheckLimitPointer, validationErrors)
-	validationErrors = validate.Parameter(params.Statuses, "statuses", validate.CheckStatusesIntsPointer, validationErrors)
-	validationErrors = validate.Parameter((*string)(params.SortBy), "sortBy", validate.CheckSortByPointer, validationErrors)
-	validationErrors = validate.Parameter(params.TakerAsset, "takerAsset", validate.CheckEthereumAddressPointer, validationErrors)
-	validationErrors = validate.Parameter(params.MakerAsset, "makerAsset", validate.CheckEthereumAddressPointer, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Page, "page", validate.CheckPage, validationErrors)
+	validationErrors = validate.Parameter(params.Limit, "limit", validate.CheckLimit, validationErrors)
+	validationErrors = validate.Parameter(params.Statuses, "statuses", validate.CheckStatusesInts, validationErrors)
+	validationErrors = validate.Parameter((string)(params.SortBy), "sortBy", validate.CheckSortBy, validationErrors)
+	validationErrors = validate.Parameter(params.TakerAsset, "takerAsset", validate.CheckEthereumAddress, validationErrors)
+	validationErrors = validate.Parameter(params.MakerAsset, "makerAsset", validate.CheckEthereumAddress, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
 
@@ -70,7 +70,7 @@ type GetCountParams struct {
 
 func (params *GetCountParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
 	validationErrors = validate.Parameter(params.Statuses, "statuses", validate.CheckStatusesStrings, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
@@ -82,8 +82,8 @@ type GetEventParams struct {
 
 func (params *GetEventParams) Validate() error { // TODO Find validation criteria for OrderHash
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.OrderHash, "orderHash", validate.CheckOrderHash, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.OrderHash, "orderHash", validate.CheckOrderHashRequired, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
 
@@ -94,7 +94,7 @@ type GetEventsParams struct {
 
 func (params *GetEventsParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
 	validationErrors = validate.Parameter(params.Limit, "limit", validate.CheckLimit, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
@@ -107,8 +107,8 @@ type GetActiveOrdersWithPermitParams struct {
 
 func (params *GetActiveOrdersWithPermitParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.Wallet, "wallet", validate.CheckPrivateKey, validationErrors)
-	validationErrors = validate.Parameter(params.Token, "token", validate.CheckEthereumAddress, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Wallet, "wallet", validate.CheckPrivateKeyRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Token, "token", validate.CheckEthereumAddressRequired, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }

--- a/golang/client/orderbook/orderbook_types_test.go
+++ b/golang/client/orderbook/orderbook_types_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/1inch/1inch-sdk/golang/client/validate"
-	"github.com/1inch/1inch-sdk/golang/helpers"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/chains"
 )
 
@@ -75,12 +74,12 @@ func TestGetOrdersByCreatorAddressParams_Validate(t *testing.T) {
 				ChainId:        chains.Ethereum,
 				CreatorAddress: "0x1234567890abcdef1234567890abcdef12345678",
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:       helpers.GetPtr(float32(1)),
-					Limit:      helpers.GetPtr(float32(1)),
-					Statuses:   helpers.GetPtr([]float32{1}),
-					SortBy:     helpers.GetPtr(LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortByCreateDateTime),
-					TakerAsset: helpers.GetPtr("0x1234567890abcdef1234567890abcdef12345678"),
-					MakerAsset: helpers.GetPtr("0x1234567890abcdef1234567890abcdef12345678"),
+					Page:       1,
+					Limit:      1,
+					Statuses:   []float32{1},
+					SortBy:     LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortByCreateDateTime,
+					TakerAsset: "0x1234567890abcdef1234567890abcdef12345678",
+					MakerAsset: "0x1234567890abcdef1234567890abcdef12345678",
 				},
 			},
 		},
@@ -124,12 +123,12 @@ func TestGetAllOrdersParams_Validate(t *testing.T) {
 			params: GetAllOrdersParams{
 				ChainId: chains.Ethereum,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:       helpers.GetPtr(float32(1)),
-					Limit:      helpers.GetPtr(float32(1)),
-					Statuses:   helpers.GetPtr([]float32{1}),
-					SortBy:     helpers.GetPtr(LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortByCreateDateTime),
-					TakerAsset: helpers.GetPtr("0x1234567890abcdef1234567890abcdef12345678"),
-					MakerAsset: helpers.GetPtr("0x1234567890abcdef1234567890abcdef12345678"),
+					Page:       1,
+					Limit:      1,
+					Statuses:   []float32{1},
+					SortBy:     LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortByCreateDateTime,
+					TakerAsset: "0x1234567890abcdef1234567890abcdef12345678",
+					MakerAsset: "0x1234567890abcdef1234567890abcdef12345678",
 				},
 			},
 		},
@@ -256,17 +255,26 @@ func TestGetEventsParams_Validate(t *testing.T) {
 			description: "Valid parameters",
 			params: GetEventsParams{
 				ChainId: chains.Ethereum,
-				LimitOrderV3SubscribedApiControllerGetEventsParams: LimitOrderV3SubscribedApiControllerGetEventsParams{
-					Limit: 1,
-				},
 			},
 		},
 		{
-			description: "Missing required parameters",
-			params:      GetEventsParams{},
+			description: "Invalid chain id",
+			params: GetEventsParams{
+				ChainId: -1,
+			},
 			expectErrors: []string{
-				"'chainId' is required",
-				"'limit': must be greater than 0", // TODO is this what I want to check here?
+				"'chainId': is invalid",
+			},
+		},
+		{
+			description: "Invalid limit parameter",
+			params: GetEventsParams{
+				ChainId: chains.Ethereum,
+				LimitOrderV3SubscribedApiControllerGetEventsParams: LimitOrderV3SubscribedApiControllerGetEventsParams{
+					Limit: -1,
+				}},
+			expectErrors: []string{
+				"'limit': must be greater than 0",
 			},
 		},
 	}

--- a/golang/client/orderbook_test.go
+++ b/golang/client/orderbook_test.go
@@ -57,35 +57,28 @@ func TestCreateOrder(t *testing.T) {
 			},
 			expectedErrorDescription: `'toToken' is required in the request config`,
 		},
-		// TODO commenting these out until we make validation logic for big ints represented as strings
-		//{
-		//	description: "Error - TakingAmount negative",
-		//	owner:       addresses.Vitalik,
-		//	params: orderbook.CreateOrderParams{
-		//      Chain: orderbook.Chain{
-		//      	ChainId:      137,
-		//      },
-		//		FromToken:    tokens.PolygonDai,
-		//		ToToken:      tokens.PolygonWeth,
-		//		TakingAmount: "-1",
-		//		MakingAmount: "100",
-		//	},
-		//	expectedErrorDescription: `'TakingAmount' failed on the 'gt' tag`,
-		//},
-		//{
-		//	description: "Error - MakingAmount negative",
-		//	owner:       addresses.Vitalik,
-		//	params: orderbook.CreateOrderParams{
-		//      Chain: orderbook.Chain{
-		//      	ChainId:      137,
-		//      },
-		//		FromToken:    tokens.PolygonDai,
-		//		ToToken:      tokens.PolygonWeth,
-		//		TakingAmount: "100",
-		//		MakingAmount: "-1",
-		//	},
-		//	expectedErrorDescription: `'MakingAmount' failed on the 'gt' tag`,
-		//},
+		{
+			description: "Error - TakingAmount negative",
+			owner:       addresses.Vitalik,
+			params: orderbook.CreateOrderParams{
+				ChainId:      chains.Polygon,
+				FromToken:    tokens.PolygonDai,
+				TakingAmount: "-1",
+				MakingAmount: "100",
+			},
+			expectedErrorDescription: `'takingAmount': must be a positive value`,
+		},
+		{
+			description: "Error - MakingAmount negative",
+			owner:       addresses.Vitalik,
+			params: orderbook.CreateOrderParams{
+				ChainId:      chains.Polygon,
+				FromToken:    tokens.PolygonDai,
+				TakingAmount: "100",
+				MakingAmount: "-1",
+			},
+			expectedErrorDescription: `'makingAmount': must be a positive value`,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/golang/client/orderbook_test.go
+++ b/golang/client/orderbook_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/1inch/1inch-sdk/golang/client/orderbook"
-	"github.com/1inch/1inch-sdk/golang/helpers"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/addresses"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/chains"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/tokens"
@@ -157,32 +156,31 @@ func TestGetOrdersByCreatorAddress(t *testing.T) {
 				ChainId:        chains.Ethereum,
 				CreatorAddress: addresses.Vitalik,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page: helpers.GetPtr(float32(0)),
+					Page: -1,
 				},
 			},
 			expectedErrorDescription: `'page': must be greater than 0`,
 		},
-		// TODO this is an edge case about how to differentiate between zero and missing params
-		//{
-		//	description: "Error - Invalid limit value",
-		//	params: orderbook.GetOrdersByCreatorAddressParams{
-		//		ChainId:        chains.Ethereum,
-		//		CreatorAddress: addresses.Vitalik,
-		//		LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-		//			Limit: helpers.GetPtr(float32(0)),
-		//		},
-		//	},
-		//	expectedErrorDescription: `'limit': must be greater than 0`,
-		//},
+		{
+			description: "Error - Invalid limit value",
+			params: orderbook.GetOrdersByCreatorAddressParams{
+				ChainId:        chains.Ethereum,
+				CreatorAddress: addresses.Vitalik,
+				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
+					Limit: -1,
+				},
+			},
+			expectedErrorDescription: `'limit': must be greater than 0`,
+		},
 		{
 			description: "Error - Invalid status",
 			params: orderbook.GetOrdersByCreatorAddressParams{
 				ChainId:        chains.Ethereum,
 				CreatorAddress: addresses.Vitalik,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:     helpers.GetPtr(float32(1)),
-					Limit:    helpers.GetPtr(float32(2)),
-					Statuses: &[]float32{0, 2},
+					Page:     1,
+					Limit:    2,
+					Statuses: []float32{0, 2},
 				},
 			},
 			expectedErrorDescription: `'statuses': can only contain [1 2 3]`,
@@ -193,9 +191,9 @@ func TestGetOrdersByCreatorAddress(t *testing.T) {
 				ChainId:        chains.Ethereum,
 				CreatorAddress: addresses.Vitalik,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:   helpers.GetPtr(float32(1)),
-					Limit:  helpers.GetPtr(float32(2)),
-					SortBy: orderbook.GetSortByParameter("invalid"),
+					Page:   1,
+					Limit:  2,
+					SortBy: "invalid",
 				},
 			},
 			expectedErrorDescription: `'sortBy': can only contain [createDateTime takerRate makerRate makerAmount takerAmount]`,
@@ -206,9 +204,9 @@ func TestGetOrdersByCreatorAddress(t *testing.T) {
 				ChainId:        chains.Ethereum,
 				CreatorAddress: addresses.Vitalik,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:       helpers.GetPtr(float32(1)),
-					Limit:      helpers.GetPtr(float32(2)),
-					TakerAsset: helpers.GetPtr("invalid"),
+					Page:       1,
+					Limit:      2,
+					TakerAsset: "invalid",
 				},
 			},
 			expectedErrorDescription: `'takerAsset': not a valid Ethereum address`,
@@ -219,9 +217,9 @@ func TestGetOrdersByCreatorAddress(t *testing.T) {
 				ChainId:        chains.Ethereum,
 				CreatorAddress: addresses.Vitalik,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:       helpers.GetPtr(float32(1)),
-					Limit:      helpers.GetPtr(float32(2)),
-					MakerAsset: helpers.GetPtr("invalid"),
+					Page:       1,
+					Limit:      2,
+					MakerAsset: "invalid",
 				},
 			},
 			expectedErrorDescription: `'makerAsset': not a valid Ethereum address`,
@@ -283,34 +281,23 @@ func TestGetAllOrders(t *testing.T) {
 			expectedOutput: defaultSignature,
 		},
 		{
-			description: "Error - Invalid page value",
+			description: "Error - Invalid limit value",
 			params: orderbook.GetAllOrdersParams{
 				ChainId: chains.Ethereum,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page: helpers.GetPtr(float32(0)),
+					Limit: -1,
 				},
 			},
-			expectedErrorDescription: `'page': must be greater than 0`,
+			expectedErrorDescription: `config validation error 'limit': must be greater than 0`,
 		},
-		// TODO this is an edge case about how to differentiate between zero and missing params1
-		//{
-		//	description: "Error - Invalid limit value",
-		//	params: orderbook.GetAllOrdersParams{
-		//		ChainId: chains.Ethereum,
-		//		LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-		//			Limit: helpers.GetPtr(float32(0)),
-		//		},
-		//	},
-		//	expectedErrorDescription: `config validation error 'limit': must be greater than 0`,
-		//},
 		{
 			description: "Error - Invalid status",
 			params: orderbook.GetAllOrdersParams{
 				ChainId: chains.Ethereum,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:     helpers.GetPtr(float32(1)),
-					Limit:    helpers.GetPtr(float32(2)),
-					Statuses: &[]float32{0, 2},
+					Page:     1,
+					Limit:    2,
+					Statuses: []float32{0, 2},
 				},
 			},
 			expectedErrorDescription: `'statuses': can only contain [1 2 3]`,
@@ -320,9 +307,9 @@ func TestGetAllOrders(t *testing.T) {
 			params: orderbook.GetAllOrdersParams{
 				ChainId: chains.Ethereum,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:   helpers.GetPtr(float32(1)),
-					Limit:  helpers.GetPtr(float32(2)),
-					SortBy: orderbook.GetSortByParameter("invalid"),
+					Page:   1,
+					Limit:  2,
+					SortBy: "invalid",
 				},
 			},
 			expectedErrorDescription: `'sortBy': can only contain [createDateTime takerRate makerRate makerAmount takerAmount]`,
@@ -332,9 +319,9 @@ func TestGetAllOrders(t *testing.T) {
 			params: orderbook.GetAllOrdersParams{
 				ChainId: chains.Ethereum,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:       helpers.GetPtr(float32(1)),
-					Limit:      helpers.GetPtr(float32(2)),
-					TakerAsset: helpers.GetPtr("invalid"),
+					Page:       1,
+					Limit:      2,
+					TakerAsset: "invalid",
 				},
 			},
 			expectedErrorDescription: `'takerAsset': not a valid Ethereum address`,
@@ -344,9 +331,9 @@ func TestGetAllOrders(t *testing.T) {
 			params: orderbook.GetAllOrdersParams{
 				ChainId: chains.Ethereum,
 				LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-					Page:       helpers.GetPtr(float32(1)),
-					Limit:      helpers.GetPtr(float32(2)),
-					MakerAsset: helpers.GetPtr("invalid"),
+					Page:       1,
+					Limit:      2,
+					MakerAsset: "invalid",
 				},
 			},
 			expectedErrorDescription: "'makerAsset': not a valid Ethereum address",

--- a/golang/client/swap/swap_types.gen.go
+++ b/golang/client/swap/swap_types.gen.go
@@ -90,10 +90,10 @@ type QuoteResponse struct {
 	FromToken *TokenInfo `json:"fromToken,omitempty"`
 
 	// Gas Estimated gas
-	Gas *float32 `json:"gas,omitempty"`
+	Gas float32 `json:"gas,omitempty"`
 
 	// Protocols Selected protocols in a path
-	Protocols *[][][]SelectedProtocol `json:"protocols,omitempty"`
+	Protocols [][][]SelectedProtocol `json:"protocols,omitempty"`
 
 	// ToAmount Expected amount of destination token
 	ToAmount string `json:"toAmount"`
@@ -150,7 +150,7 @@ type SwapResponse struct {
 	FromToken *TokenInfo `json:"fromToken,omitempty"`
 
 	// Protocols Selected protocols in a path
-	Protocols *[][][]SelectedProtocol `json:"protocols,omitempty"`
+	Protocols [][][]SelectedProtocol `json:"protocols,omitempty"`
 
 	// ToAmount Expected amount of destination token
 	ToAmount string `json:"toAmount"`
@@ -164,15 +164,15 @@ type SwapResponse struct {
 
 // TokenInfo defines model for TokenInfo.
 type TokenInfo struct {
-	Address       string    `json:"address"`
-	Decimals      float32   `json:"decimals"`
-	DomainVersion *string   `json:"domainVersion,omitempty"`
-	Eip2612       *bool     `json:"eip2612,omitempty"`
-	IsFoT         *bool     `json:"isFoT,omitempty"`
-	LogoURI       string    `json:"logoURI"`
-	Name          string    `json:"name"`
-	Symbol        string    `json:"symbol"`
-	Tags          *[]string `json:"tags,omitempty"`
+	Address       string   `json:"address"`
+	Decimals      float32  `json:"decimals"`
+	DomainVersion string   `json:"domainVersion,omitempty"`
+	Eip2612       bool     `json:"eip2612,omitempty"`
+	IsFoT         bool     `json:"isFoT,omitempty"`
+	LogoURI       string   `json:"logoURI"`
+	Name          string   `json:"name"`
+	Symbol        string   `json:"symbol"`
+	Tags          []string `json:"tags,omitempty"`
 }
 
 // TokensResponse defines model for TokensResponse.
@@ -205,7 +205,7 @@ type ApproveControllerGetCallDataParams struct {
 	TokenAddress string `url:"tokenAddress" json:"tokenAddress"`
 
 	// Amount The number of tokens that the 1inch Router is allowed to swap.If not specified, it will be allowed to spend an infinite amount of tokens.
-	Amount *string `url:"amount,omitempty" json:"amount,omitempty"`
+	Amount string `url:"amount,omitempty" json:"amount,omitempty"`
 }
 
 // AggregationControllerGetQuoteParams defines parameters for AggregationControllerGetQuote.
@@ -215,27 +215,27 @@ type AggregationControllerGetQuoteParams struct {
 	Amount string `url:"amount" json:"amount"`
 
 	// Protocols All supported liquidity sources by default
-	Protocols *string `url:"protocols,omitempty" json:"protocols,omitempty"`
+	Protocols string `url:"protocols,omitempty" json:"protocols,omitempty"`
 
 	// Fee Partner fee. min: 0; max: 3 Should be the same for /quote and /swap
-	Fee *float32 `url:"fee,omitempty" json:"fee,omitempty"`
+	Fee float32 `url:"fee,omitempty" json:"fee,omitempty"`
 
 	// GasPrice Network price per gas in wei. By default fast network gas price
-	GasPrice        *string  `url:"gasPrice,omitempty" json:"gasPrice,omitempty"`
-	ComplexityLevel *float32 `url:"complexityLevel,omitempty" json:"complexityLevel,omitempty"`
-	Parts           *float32 `url:"parts,omitempty" json:"parts,omitempty"`
-	MainRouteParts  *float32 `url:"mainRouteParts,omitempty" json:"mainRouteParts,omitempty"`
-	GasLimit        *float32 `url:"gasLimit,omitempty" json:"gasLimit,omitempty"`
+	GasPrice        string  `url:"gasPrice,omitempty" json:"gasPrice,omitempty"`
+	ComplexityLevel float32 `url:"complexityLevel,omitempty" json:"complexityLevel,omitempty"`
+	Parts           float32 `url:"parts,omitempty" json:"parts,omitempty"`
+	MainRouteParts  float32 `url:"mainRouteParts,omitempty" json:"mainRouteParts,omitempty"`
+	GasLimit        float32 `url:"gasLimit,omitempty" json:"gasLimit,omitempty"`
 
 	// IncludeTokensInfo Return fromToken and toToken info in response
-	IncludeTokensInfo *bool `url:"includeTokensInfo,omitempty" json:"includeTokensInfo,omitempty"`
+	IncludeTokensInfo bool `url:"includeTokensInfo,omitempty" json:"includeTokensInfo,omitempty"`
 
 	// IncludeProtocols Return used swap protocols in response
-	IncludeProtocols *bool `url:"includeProtocols,omitempty" json:"includeProtocols,omitempty"`
+	IncludeProtocols bool `url:"includeProtocols,omitempty" json:"includeProtocols,omitempty"`
 
 	// IncludeGas Return approximated gas in response
-	IncludeGas      *bool   `url:"includeGas,omitempty" json:"includeGas,omitempty"`
-	ConnectorTokens *string `url:"connectorTokens,omitempty" json:"connectorTokens,omitempty"`
+	IncludeGas      bool   `url:"includeGas,omitempty" json:"includeGas,omitempty"`
+	ConnectorTokens string `url:"connectorTokens,omitempty" json:"connectorTokens,omitempty"`
 }
 
 // AggregationControllerGetSwapParams defines parameters for AggregationControllerGetSwap.
@@ -251,38 +251,38 @@ type AggregationControllerGetSwapParams struct {
 	Slippage float32 `url:"slippage" json:"slippage"`
 
 	// Protocols All supported liquidity sources by default
-	Protocols *string `url:"protocols,omitempty" json:"protocols,omitempty"`
+	Protocols string `url:"protocols,omitempty" json:"protocols,omitempty"`
 
 	// Fee Partner fee. min: 0; max: 3 Should be the same for /quote and /swap
-	Fee *float32 `url:"fee,omitempty" json:"fee,omitempty"`
+	Fee float32 `url:"fee,omitempty" json:"fee,omitempty"`
 
 	// GasPrice Network price per gas in wei. By default fast network gas price
-	GasPrice        *string  `url:"gasPrice,omitempty" json:"gasPrice,omitempty"`
-	ComplexityLevel *float32 `url:"complexityLevel,omitempty" json:"complexityLevel,omitempty"`
-	Parts           *float32 `url:"parts,omitempty" json:"parts,omitempty"`
-	MainRouteParts  *float32 `url:"mainRouteParts,omitempty" json:"mainRouteParts,omitempty"`
-	GasLimit        *float32 `url:"gasLimit,omitempty" json:"gasLimit,omitempty"`
+	GasPrice        string  `url:"gasPrice,omitempty" json:"gasPrice,omitempty"`
+	ComplexityLevel float32 `url:"complexityLevel,omitempty" json:"complexityLevel,omitempty"`
+	Parts           float32 `url:"parts,omitempty" json:"parts,omitempty"`
+	MainRouteParts  float32 `url:"mainRouteParts,omitempty" json:"mainRouteParts,omitempty"`
+	GasLimit        float32 `url:"gasLimit,omitempty" json:"gasLimit,omitempty"`
 
 	// IncludeTokensInfo Return fromToken and toToken info in response
-	IncludeTokensInfo *bool `url:"includeTokensInfo,omitempty" json:"includeTokensInfo,omitempty"`
+	IncludeTokensInfo bool `url:"includeTokensInfo,omitempty" json:"includeTokensInfo,omitempty"`
 
 	// IncludeProtocols Return used swap protocols in response
-	IncludeProtocols *bool `url:"includeProtocols,omitempty" json:"includeProtocols,omitempty"`
+	IncludeProtocols bool `url:"includeProtocols,omitempty" json:"includeProtocols,omitempty"`
 
 	// IncludeGas Return approximated gas in response
-	IncludeGas      *bool   `url:"includeGas,omitempty" json:"includeGas,omitempty"`
-	ConnectorTokens *string `url:"connectorTokens,omitempty" json:"connectorTokens,omitempty"`
+	IncludeGas      bool   `url:"includeGas,omitempty" json:"includeGas,omitempty"`
+	ConnectorTokens string `url:"connectorTokens,omitempty" json:"connectorTokens,omitempty"`
 
 	// Permit https://eips.ethereum.org/EIPS/eip-2612
-	Permit *string `url:"permit,omitempty" json:"permit,omitempty"`
+	Permit string `url:"permit,omitempty" json:"permit,omitempty"`
 
 	// Receiver This address will receive funds after the swap. By default same address as "from" param
-	Receiver *string `url:"receiver,omitempty" json:"receiver,omitempty"`
-	Referrer *string `url:"referrer,omitempty" json:"referrer,omitempty"`
+	Receiver string `url:"receiver,omitempty" json:"receiver,omitempty"`
+	Referrer string `url:"referrer,omitempty" json:"referrer,omitempty"`
 
 	// AllowPartialFill By default set to false
-	AllowPartialFill *bool `url:"allowPartialFill,omitempty" json:"allowPartialFill,omitempty"`
+	AllowPartialFill bool `url:"allowPartialFill,omitempty" json:"allowPartialFill,omitempty"`
 
 	// DisableEstimate Enable this flag to disable onchain simulation
-	DisableEstimate *bool `url:"disableEstimate,omitempty" json:"disableEstimate,omitempty"`
+	DisableEstimate bool `url:"disableEstimate,omitempty" json:"disableEstimate,omitempty"`
 }

--- a/golang/client/swap/swap_types.go
+++ b/golang/client/swap/swap_types.go
@@ -18,14 +18,14 @@ type SwapTokensParams struct {
 func (params *SwapTokensParams) Validate() error {
 	var validationErrors []error
 	validationErrors = validate.Parameter(int(params.ApprovalType), "approvalType", validate.CheckApprovalType, validationErrors)
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.PublicAddress, "publicAddress", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.WalletKey, "walletKey", validate.CheckPrivateKey, validationErrors)
-	validationErrors = validate.Parameter(params.Src, "src", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Dst, "dst", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Amount, "amount", validate.CheckBigInt, validationErrors)
-	validationErrors = validate.Parameter(params.From, "from", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Slippage, "slippage", validate.CheckSlippage, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.PublicAddress, "publicAddress", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.WalletKey, "walletKey", validate.CheckPrivateKeyRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Src, "src", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Dst, "dst", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Amount, "amount", validate.CheckBigIntRequired, validationErrors)
+	validationErrors = validate.Parameter(params.From, "from", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Slippage, "slippage", validate.CheckSlippageRequired, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
 
@@ -36,9 +36,9 @@ type ApproveAllowanceParams struct {
 
 func (params *ApproveAllowanceParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.TokenAddress, "tokenAddress", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.WalletAddress, "walletAddress", validate.CheckEthereumAddress, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.TokenAddress, "tokenAddress", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.WalletAddress, "walletAddress", validate.CheckEthereumAddressRequired, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
 
@@ -48,7 +48,7 @@ type ApproveSpenderParams struct {
 
 func (params *ApproveSpenderParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
 
@@ -59,9 +59,9 @@ type ApproveTransactionParams struct {
 
 func (params *ApproveTransactionParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.TokenAddress, "tokenAddress", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Amount, "amount", validate.CheckBigIntPointer, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.TokenAddress, "tokenAddress", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Amount, "amount", validate.CheckBigInt, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
 
@@ -71,7 +71,7 @@ type GetLiquiditySourcesParams struct {
 
 func (params *GetLiquiditySourcesParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }
 
@@ -82,10 +82,10 @@ type GetQuoteParams struct {
 
 func (params *GetQuoteParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.Src, "src", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Dst, "dst", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Amount, "amount", validate.CheckBigInt, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Src, "src", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Dst, "dst", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Amount, "amount", validate.CheckBigIntRequired, validationErrors)
 	if len(params.Src) > 0 && len(params.Dst) > 0 && params.Src == params.Dst {
 		validationErrors = append(validationErrors, errors.New("src and dst tokens must be different"))
 	}
@@ -100,12 +100,12 @@ type GetSwapDataParams struct {
 
 func (params *GetSwapDataParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
-	validationErrors = validate.Parameter(params.Src, "src", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Dst, "dst", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Amount, "amount", validate.CheckBigInt, validationErrors)
-	validationErrors = validate.Parameter(params.From, "from", validate.CheckEthereumAddress, validationErrors)
-	validationErrors = validate.Parameter(params.Slippage, "slippage", validate.CheckSlippage, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Src, "src", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Dst, "dst", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Amount, "amount", validate.CheckBigIntRequired, validationErrors)
+	validationErrors = validate.Parameter(params.From, "from", validate.CheckEthereumAddressRequired, validationErrors)
+	validationErrors = validate.Parameter(params.Slippage, "slippage", validate.CheckSlippageRequired, validationErrors)
 	if len(params.Src) > 0 && len(params.Dst) > 0 && params.Src == params.Dst {
 		validationErrors = append(validationErrors, errors.New("src and dst tokens must be different"))
 	}
@@ -118,6 +118,6 @@ type GetTokensParams struct {
 
 func (params *GetTokensParams) Validate() error {
 	var validationErrors []error
-	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainId, validationErrors)
+	validationErrors = validate.Parameter(params.ChainId, "chainId", validate.CheckChainIdRequired, validationErrors)
 	return validate.ConsolidateValidationErorrs(validationErrors)
 }

--- a/golang/client/swap_actions.go
+++ b/golang/client/swap_actions.go
@@ -10,13 +10,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+
 	"github.com/1inch/1inch-sdk/golang/client/tenderly"
 	"github.com/1inch/1inch-sdk/golang/helpers"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/chains"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/tokens"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/1inch/1inch-sdk/golang/client/onchain"
 	"github.com/1inch/1inch-sdk/golang/client/swap"
@@ -53,7 +54,7 @@ type ActionService service
 func (s *ActionService) SwapTokens(params swap.SwapTokensParams) error {
 
 	// Always disable estimate so we can don onchain approvals for the swaps right before we execute
-	params.DisableEstimate = helpers.GetPtr(true)
+	params.DisableEstimate = true
 
 	// TODO find a better way of managing the matching between public and private keys
 	privateKey, err := crypto.HexToECDSA(params.WalletKey)
@@ -151,7 +152,7 @@ func (s *ActionService) SwapTokens(params swap.SwapTokensParams) error {
 		})
 
 		executeSwapConfig.IsPermitSwap = true
-		params.Permit = &permitParams
+		params.Permit = permitParams
 		fmt.Println("Swapping using Permit1")
 	}
 

--- a/golang/client/swap_integration_test.go
+++ b/golang/client/swap_integration_test.go
@@ -102,7 +102,7 @@ func TestApproveTransactionIntegration(t *testing.T) {
 				ChainId: chains.Ethereum,
 				ApproveControllerGetCallDataParams: swap.ApproveControllerGetCallDataParams{
 					TokenAddress: tokens.EthereumUsdc,
-					Amount:       nil,
+					Amount:       "",
 				},
 			},
 			expectedOutput: swap.ApproveCallDataResponse{
@@ -184,7 +184,7 @@ func TestGetTokensIntegration(t *testing.T) {
 			expectedToken: swap.TokenInfo{
 				Address:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
 				Decimals: 6,
-				Eip2612:  helpers.GetPtr(true),
+				Eip2612:  true,
 				Name:     "USD Coin",
 				Symbol:   "USDC",
 			},

--- a/golang/client/validate/validate.go
+++ b/golang/client/validate/validate.go
@@ -9,18 +9,7 @@ import (
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/chains"
 )
 
-func CheckEthereumAddressPointer(parameter interface{}, variableName string) error {
-	value, ok := parameter.(*string)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string pointer", variableName, "EthereumAddressPointer")
-	}
-	if value == nil {
-		return nil
-	}
-	return CheckEthereumAddress(*value, variableName)
-}
-
-func CheckEthereumAddress(parameter interface{}, variableName string) error {
+func CheckEthereumAddressRequired(parameter interface{}, variableName string) error {
 	value, ok := parameter.(string)
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string", variableName, "EthereumAddress")
@@ -30,6 +19,17 @@ func CheckEthereumAddress(parameter interface{}, variableName string) error {
 		return NewParameterMissingError(variableName)
 	}
 
+	return CheckEthereumAddress(value, variableName)
+}
+func CheckEthereumAddress(parameter interface{}, variableName string) error {
+	value, ok := parameter.(string)
+	if !ok {
+		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string", variableName, "EthereumAddress")
+	}
+	if value == "" {
+		return nil
+	}
+
 	re := regexp.MustCompile(`^0x[a-fA-F0-9]{40}$`)
 	if !re.MatchString(value) {
 		return NewParameterValidationError(variableName, "not a valid Ethereum address")
@@ -37,21 +37,10 @@ func CheckEthereumAddress(parameter interface{}, variableName string) error {
 	return nil
 }
 
-func CheckBigIntPointer(parameter interface{}, variableName string) error {
-	value, ok := parameter.(*string)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string pointer", variableName, "BigIntPointer")
-	}
-	if value == nil {
-		return nil
-	}
-	return CheckBigInt(*value, variableName)
-}
-
 var bigIntMax, _ = helpers.BigIntFromString("115792089237316195423570985008687907853269984665640564039457584007913129639935")
 var bigIntZero = big.NewInt(0)
 
-func CheckBigInt(parameter interface{}, variableName string) error {
+func CheckBigIntRequired(parameter interface{}, variableName string) error {
 	value, ok := parameter.(string)
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string", variableName, "BigInt")
@@ -59,6 +48,18 @@ func CheckBigInt(parameter interface{}, variableName string) error {
 
 	if value == "" {
 		return NewParameterMissingError(variableName)
+	}
+
+	return CheckBigInt(value, variableName)
+}
+func CheckBigInt(parameter interface{}, variableName string) error {
+	value, ok := parameter.(string)
+	if !ok {
+		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string", variableName, "BigInt")
+	}
+
+	if value == "" {
+		return nil
 	}
 
 	parsedValue, err := helpers.BigIntFromString(value)
@@ -74,7 +75,7 @@ func CheckBigInt(parameter interface{}, variableName string) error {
 	return nil
 }
 
-func CheckChainId(parameter interface{}, variableName string) error {
+func CheckChainIdRequired(parameter interface{}, variableName string) error {
 	value, ok := parameter.(int)
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be an int", variableName, "ChainId")
@@ -84,13 +85,25 @@ func CheckChainId(parameter interface{}, variableName string) error {
 		return NewParameterMissingError(variableName)
 	}
 
+	return CheckChainId(value, variableName)
+}
+
+func CheckChainId(parameter interface{}, variableName string) error {
+	value, ok := parameter.(int)
+	if !ok {
+		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be an int", variableName, "ChainId")
+	}
+	if value == 0 {
+		return nil
+	}
+
 	if !helpers.Contains(value, chains.ValidChainIds) {
-		return NewParameterValidationError(variableName, fmt.Sprintf("invalid chain id, valid chain ids are: %v", chains.ValidChainIds))
+		return NewParameterValidationError(variableName, fmt.Sprintf("is invalid, valid chain ids are: %v", chains.ValidChainIds))
 	}
 	return nil
 }
 
-func CheckPrivateKey(parameter interface{}, variableName string) error {
+func CheckPrivateKeyRequired(parameter interface{}, variableName string) error {
 	address, ok := parameter.(string)
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string", variableName, "PrivateKey")
@@ -100,53 +113,21 @@ func CheckPrivateKey(parameter interface{}, variableName string) error {
 		return NewParameterMissingError(variableName)
 	}
 
+	return CheckPrivateKey(address, variableName)
+}
+func CheckPrivateKey(parameter interface{}, variableName string) error {
+	address, ok := parameter.(string)
+	if !ok {
+		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string", variableName, "PrivateKey")
+	}
+
+	if address == "" {
+		return nil
+	}
+
 	re := regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
 	if !re.MatchString(address) {
 		return NewParameterValidationError(variableName, "not a valid private key")
-	}
-	return nil
-}
-
-func CheckFloat32NonZeroPointer(parameter interface{}, variableName string) error {
-	value, ok := parameter.(*float32)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32 pointer", variableName, "Float32NonZeroPointer")
-	}
-	if value == nil {
-		return nil
-	}
-	return CheckFloat32NonZero(*value, variableName)
-}
-
-func CheckFloat32NonZero(parameter interface{}, variableName string) error {
-	value, ok := parameter.(float32)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32", variableName, "Float32NonZero")
-	}
-	if value < 1 {
-		return NewParameterValidationError(variableName, "must be explicitly set to a value greater than 0")
-	}
-	return nil
-}
-
-func CheckFloat32Pointer(parameter interface{}, variableName string) error {
-	value, ok := parameter.(*float32)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32 pointer", variableName, "Float32Pointer")
-	}
-	if value == nil {
-		return nil
-	}
-	return CheckFloat32(*value, variableName)
-}
-
-func CheckFloat32(parameter interface{}, variableName string) error {
-	value, ok := parameter.(float32)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32", variableName, "Float32")
-	}
-	if value < 0 {
-		return NewParameterValidationError(variableName, "must be non-negative")
 	}
 	return nil
 }
@@ -157,13 +138,17 @@ func CheckApprovalType(parameter interface{}, variableName string) error {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be an int", variableName, "ApprovalType")
 	}
 
+	if value == 0 {
+		return nil
+	}
+
 	if !helpers.Contains(value, []int{0, 1, 2}) {
 		return NewParameterValidationError(variableName, "invalid approval type")
 	}
 	return nil
 }
 
-func CheckSlippage(parameter interface{}, variableName string) error {
+func CheckSlippageRequired(parameter interface{}, variableName string) error {
 	value, ok := parameter.(float32)
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32", variableName, "Slippage")
@@ -171,21 +156,20 @@ func CheckSlippage(parameter interface{}, variableName string) error {
 	if value == 0 {
 		return NewParameterMissingError(variableName)
 	}
+	return CheckSlippage(value, variableName)
+}
+func CheckSlippage(parameter interface{}, variableName string) error {
+	value, ok := parameter.(float32)
+	if !ok {
+		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32", variableName, "Slippage")
+	}
+	if value == 0 {
+		return nil
+	}
 	if value < 0.01 || value > 50 {
 		return NewParameterValidationError(variableName, fmt.Sprintf("invalid slippage value (%v) - only values 0.01-50 are allowed", value))
 	}
 	return nil
-}
-
-func CheckPagePointer(parameter interface{}, variableName string) error {
-	value, ok := parameter.(*float32)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32 pointer", variableName, "PagePointer")
-	}
-	if value == nil {
-		return nil
-	}
-	return CheckPage(*value, variableName)
 }
 
 func CheckPage(parameter interface{}, variableName string) error {
@@ -193,22 +177,14 @@ func CheckPage(parameter interface{}, variableName string) error {
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32", variableName, "Page")
 	}
+	if value == 0 {
+		return nil
+	}
 
 	if value < 1 {
 		return NewParameterValidationError(variableName, "must be greater than 0")
 	}
 	return nil
-}
-
-func CheckLimitPointer(parameter interface{}, variableName string) error {
-	value, ok := parameter.(*float32)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32 pointer", variableName, "LimitPointer")
-	}
-	if value == nil {
-		return nil
-	}
-	return CheckLimit(*value, variableName)
 }
 
 func CheckLimit(parameter interface{}, variableName string) error {
@@ -216,6 +192,9 @@ func CheckLimit(parameter interface{}, variableName string) error {
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a float32", variableName, "Limit")
 	}
+	if value == 0 {
+		return nil
+	}
 
 	if value < 1 {
 		return NewParameterValidationError(variableName, "must be greater than 0")
@@ -223,21 +202,14 @@ func CheckLimit(parameter interface{}, variableName string) error {
 	return nil
 }
 
-func CheckStatusesIntsPointer(parameter interface{}, variableName string) error {
-	value, ok := parameter.(*[]float32)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a *[]float32 pointer", variableName, "StatusesIntsPointer")
-	}
-	if value == nil {
-		return nil
-	}
-	return CheckStatusesInts(*value, variableName)
-}
-
 func CheckStatusesInts(parameter interface{}, variableName string) error {
 	value, ok := parameter.([]float32)
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a []float32", variableName, "StatusesInts")
+	}
+
+	if value == nil {
+		return nil
 	}
 
 	if helpers.HasDuplicates(value) {
@@ -248,17 +220,6 @@ func CheckStatusesInts(parameter interface{}, variableName string) error {
 		return NewParameterValidationError(variableName, fmt.Sprintf("can only contain %v", validStatuses))
 	}
 	return nil
-}
-
-func CheckStatusesStringsPointer(parameter interface{}, variableName string) error {
-	value, ok := parameter.(*[]string)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a *[]string pointer", variableName, "StatusesStringsPointer")
-	}
-	if value == nil {
-		return nil
-	}
-	return CheckStatusesStrings(*value, variableName)
 }
 
 func CheckStatusesStrings(parameter interface{}, variableName string) error {
@@ -277,21 +238,14 @@ func CheckStatusesStrings(parameter interface{}, variableName string) error {
 	return nil
 }
 
-func CheckSortByPointer(parameter interface{}, variableName string) error {
-	value, ok := parameter.(*string)
-	if !ok {
-		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string pointer", variableName, "SortByPointer")
-	}
-	if value == nil {
-		return nil
-	}
-	return CheckSortBy(*value, variableName)
-}
-
 func CheckSortBy(parameter interface{}, variableName string) error {
 	value, ok := parameter.(string)
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string", variableName, "SortBy")
+	}
+
+	if value == "" {
+		return nil
 	}
 
 	validSortBy := []string{"createDateTime", "takerRate", "makerRate", "makerAmount", "takerAmount"}
@@ -301,7 +255,7 @@ func CheckSortBy(parameter interface{}, variableName string) error {
 	return nil
 }
 
-func CheckOrderHash(parameter interface{}, variableName string) error {
+func CheckOrderHashRequired(parameter interface{}, variableName string) error {
 	value, ok := parameter.(string)
 	if !ok {
 		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string", variableName, "OrderHash")
@@ -309,6 +263,17 @@ func CheckOrderHash(parameter interface{}, variableName string) error {
 
 	if value == "" {
 		return NewParameterMissingError(variableName)
+	}
+	return CheckOrderHash(value, variableName)
+}
+func CheckOrderHash(parameter interface{}, variableName string) error {
+	value, ok := parameter.(string)
+	if !ok {
+		return fmt.Errorf("for parameter '%v' to be validated as '%v', it must be a string", variableName, "OrderHash")
+	}
+
+	if value == "" {
+		return nil
 	}
 	// TODO add criteria that captures valid order hash strings here
 	return nil

--- a/golang/client/validate/validate.go
+++ b/golang/client/validate/validate.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"math/big"
 	"regexp"
 
 	"github.com/1inch/1inch-sdk/golang/helpers"
@@ -47,7 +48,8 @@ func CheckBigIntPointer(parameter interface{}, variableName string) error {
 	return CheckBigInt(*value, variableName)
 }
 
-var maxBigInt, _ = helpers.BigIntFromString("115792089237316195423570985008687907853269984665640564039457584007913129639935")
+var bigIntMax, _ = helpers.BigIntFromString("115792089237316195423570985008687907853269984665640564039457584007913129639935")
+var bigIntZero = big.NewInt(0)
 
 func CheckBigInt(parameter interface{}, variableName string) error {
 	value, ok := parameter.(string)
@@ -60,8 +62,14 @@ func CheckBigInt(parameter interface{}, variableName string) error {
 	}
 
 	parsedValue, err := helpers.BigIntFromString(value)
-	if err != nil || parsedValue.Cmp(maxBigInt) > 0 {
-		return NewParameterValidationError(variableName, "not a valid big integer or too big to fit in uint256")
+	if err != nil {
+		return NewParameterValidationError(variableName, "not a valid value")
+	}
+	if parsedValue.Cmp(bigIntMax) > 0 {
+		return NewParameterValidationError(variableName, "too big to fit in uint256")
+	}
+	if parsedValue.Cmp(bigIntZero) < 0 {
+		return NewParameterValidationError(variableName, "must be a positive value")
 	}
 	return nil
 }

--- a/golang/client/validate/validate_static_check_test.go
+++ b/golang/client/validate/validate_static_check_test.go
@@ -23,7 +23,7 @@ func checkParameterFunctionConsistency(filePath string) error {
 	}
 	defer file.Close()
 
-	funcRegex := regexp.MustCompile(`^func Check(\w+)\(`)
+	funcRegex := regexp.MustCompile(`^func Check(\w+)(Required)?\(`)
 	scanner := bufio.NewScanner(file)
 
 	lineNumber := 0

--- a/golang/client/validate/validate_test.go
+++ b/golang/client/validate/validate_test.go
@@ -39,11 +39,6 @@ func TestIsEthereumAddress(t *testing.T) {
 			expectError: true,
 		},
 		{
-			description: "Invalid empty address",
-			address:     "",
-			expectError: true,
-		},
-		{
 			description: "Invalid address with non-hex characters",
 			address:     "0xGHIJKL7890abcdef1234567890abcdef12345678",
 			expectError: true,
@@ -75,11 +70,6 @@ func TestBigInt(t *testing.T) {
 		{
 			description: "Value exceeding uint256 range",
 			value:       "115792089237316195423570985008687907853269984665640564039457584007913129639936",
-			expectError: true,
-		},
-		{
-			description: "Empty value",
-			value:       "",
 			expectError: true,
 		},
 		{
@@ -125,11 +115,6 @@ func TestChainId(t *testing.T) {
 			value:       999999,
 			expectError: true,
 		},
-		{
-			description: "Chain id is required",
-			value:       0,
-			expectError: true,
-		},
 	}
 
 	for _, tc := range testcases {
@@ -169,11 +154,6 @@ func TestPrivateKey(t *testing.T) {
 			address:     "a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1a2b3",
 			expectError: true,
 		},
-		{
-			description: "Empty private key",
-			address:     "",
-			expectError: true,
-		},
 	}
 
 	for _, tc := range testcases {
@@ -205,11 +185,6 @@ func TestSlippage(t *testing.T) {
 		{
 			description: "Valid slippage value - mid range",
 			value:       25,
-		},
-		{
-			description: "Invalid slippage value - empty",
-			value:       0,
-			expectError: true,
 		},
 		{
 			description: "Invalid slippage value - below lower boundary",

--- a/golang/examples/orderbook/get_orders/main.go
+++ b/golang/examples/orderbook/get_orders/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/1inch/1inch-sdk/golang/client"
 	"github.com/1inch/1inch-sdk/golang/client/orderbook"
-	"github.com/1inch/1inch-sdk/golang/helpers"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/chains"
 )
 
@@ -32,15 +31,13 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	sortBy := orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParamsSortBy("createDateTime")
-
 	// Build the config for the orders request
 	limitOrdersParams := orderbook.GetAllOrdersParams{
 		ChainId: 137,
 		LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams: orderbook.LimitOrderV3SubscribedApiControllerGetAllLimitOrdersParams{
-			Page:   helpers.GetPtr(float32(1)),
-			Limit:  helpers.GetPtr(float32(2)),
-			SortBy: &sortBy,
+			Page:   1,
+			Limit:  2,
+			SortBy: "createDateTime",
 		},
 	}
 

--- a/golang/examples/swap/swap/main.go
+++ b/golang/examples/swap/swap/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/1inch/1inch-sdk/golang/client"
 	"github.com/1inch/1inch-sdk/golang/client/swap"
-	"github.com/1inch/1inch-sdk/golang/helpers"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/amounts"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/chains"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/tokens"
@@ -42,7 +41,7 @@ func main() {
 			Dst:             tokens.PolygonWeth,
 			From:            os.Getenv("WALLET_ADDRESS"),
 			Amount:          amounts.Ten16,
-			DisableEstimate: helpers.GetPtr(true),
+			DisableEstimate: true,
 			Slippage:        0.5,
 		},
 	}

--- a/golang/examples/swap/swap_with_execute/main.go
+++ b/golang/examples/swap/swap_with_execute/main.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/1inch/1inch-sdk/golang/client"
 	"github.com/1inch/1inch-sdk/golang/client/swap"
-	"github.com/1inch/1inch-sdk/golang/helpers"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/chains"
 	"github.com/1inch/1inch-sdk/golang/helpers/consts/tokens"
 )
@@ -43,7 +42,7 @@ func main() {
 			From:            os.Getenv("WALLET_ADDRESS"),
 			Amount:          "10000000000000000",
 			Slippage:        0.5,
-			DisableEstimate: helpers.GetPtr(true),
+			DisableEstimate: true,
 		},
 	}
 

--- a/golang/helpers/pointerinitializers.go
+++ b/golang/helpers/pointerinitializers.go
@@ -1,6 +1,0 @@
-package helpers
-
-// GetPtr returns a pointer to the provided value.
-func GetPtr[T any](value T) *T {
-	return &value
-}

--- a/golang/swagger-static/orderbook-swagger.json
+++ b/golang/swagger-static/orderbook-swagger.json
@@ -11,7 +11,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/LimitOrderV3Request" }
+              "schema": {
+                "$ref": "#/components/schemas/LimitOrderV3Request"
+              }
             }
           }
         },
@@ -19,7 +21,9 @@
           "201": {
             "description": "The limit order has been successfully saved"
           },
-          "400": { "description": "Input data is invalid" },
+          "400": {
+            "description": "Input data is invalid"
+          },
           "403": {
             "description": "Max valid orders per user: 100. Cancel previous orders to create new ones"
           }
@@ -38,7 +42,9 @@
             "in": "path",
             "description": "Address of limit orders creator",
             "example": "0x0000000000000000000000000000000000000000",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "page",
@@ -46,7 +52,10 @@
             "in": "query",
             "description": "Pagination step, default: 1 (page = offset / limit)",
             "example": 1,
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
+            }
           },
           {
             "name": "limit",
@@ -54,7 +63,10 @@
             "in": "query",
             "description": "Number of limit orders to receive (default: 100, max: 500)",
             "example": 100,
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
+            }
           },
           {
             "name": "statuses",
@@ -62,7 +74,13 @@
             "in": "query",
             "description": "JSON an array of statuses by which limit orders will be filtered: 1 - valid limit orders, 2 - temporary invalid limit orders, 3 - invalid limit orders",
             "example": "[1,2,3]",
-            "schema": { "type": "array", "items": { "type": "number" } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "x-go-type-skip-optional-pointer": true
+            }
           },
           {
             "name": "sortBy",
@@ -76,7 +94,8 @@
                 "makerAmount",
                 "takerAmount"
               ],
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -84,18 +103,26 @@
             "required": false,
             "in": "query",
             "description": "Address of the taker asset",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
+            }
           },
           {
             "name": "makerAsset",
             "required": false,
             "in": "query",
             "description": "Address of the maker asset",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Array of queried limit orders" },
+          "200": {
+            "description": "Array of queried limit orders"
+          },
           "400": {
             "description": "Input data is invalid or address is not provided"
           }
@@ -114,7 +141,10 @@
             "in": "query",
             "description": "Pagination step, default: 1 (page = offset / limit)",
             "example": 1,
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
+            }
           },
           {
             "name": "limit",
@@ -122,7 +152,10 @@
             "in": "query",
             "description": "Number of limit orders to receive (default: 100, max: 500)",
             "example": 100,
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
+            }
           },
           {
             "name": "statuses",
@@ -130,7 +163,13 @@
             "in": "query",
             "description": "JSON an array of statuses by which limit orders will be filtered: 1 - valid limit orders, 2 - temporary invalid limit orders, 3 - invalid limit orders",
             "example": "[1,2,3]",
-            "schema": { "type": "array", "items": { "type": "number" } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "x-go-type-skip-optional-pointer": true
+            }
           },
           {
             "name": "sortBy",
@@ -144,7 +183,8 @@
                 "makerAmount",
                 "takerAmount"
               ],
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -152,19 +192,29 @@
             "required": false,
             "in": "query",
             "description": "Address of the maker asset",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
+            }
           },
           {
             "name": "makerAsset",
             "required": false,
             "in": "query",
             "description": "Address of the maker asset",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Array of queried limit orders" },
-          "400": { "description": "Input data is invalid" }
+          "200": {
+            "description": "Array of queried limit orders"
+          },
+          "400": {
+            "description": "Input data is invalid"
+          }
         },
         "tags": ["Limit Order V3"]
       }
@@ -177,10 +227,19 @@
             "name": "statuses",
             "required": true,
             "in": "query",
-            "schema": { "type": "array", "items": { "type": "string" } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         ],
-        "responses": { "200": { "description": "" } },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
         "tags": ["Limit Order V3"]
       }
     },
@@ -192,10 +251,16 @@
             "name": "orderHash",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
-        "responses": { "200": { "description": "" } },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
         "tags": ["Limit Order V3"]
       }
     },
@@ -207,10 +272,16 @@
             "name": "limit",
             "required": true,
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           }
         ],
-        "responses": { "200": { "description": "" } },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
         "tags": ["Limit Order V3"]
       }
     },
@@ -222,16 +293,24 @@
             "name": "walletAddress",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "token",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
-        "responses": { "200": { "description": "" } },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
         "tags": ["Limit Order V3"]
       }
     }
@@ -251,47 +330,57 @@
         "properties": {
           "makerAsset": {
             "type": "string",
-            "description": "Address of the maker asset"
+            "description": "Address of the maker asset",
+            "x-go-type-skip-optional-pointer": true
           },
           "takerAsset": {
             "type": "string",
-            "description": "Address of the taker asset"
+            "description": "Address of the taker asset",
+            "x-go-type-skip-optional-pointer": true
           },
           "maker": {
             "type": "string",
-            "description": "An address of the maker (wallet or contract address)"
+            "description": "An address of the maker (wallet or contract address)",
+            "x-go-type-skip-optional-pointer": true
           },
           "allowedSender": {
             "type": "string",
             "description": "An address of the wallet or contract who will be able to fill this order (equals to Zero address on public orders)",
-            "default": "0x0000000000000000000000000000000000000000"
+            "default": "0x0000000000000000000000000000000000000000",
+            "x-go-type-skip-optional-pointer": true
           },
           "receiver": {
             "type": "string",
             "description": "An address of the wallet or contract who will receive filled amount (equals to Zero address for receiver == makerAddress)",
-            "default": "0x0000000000000000000000000000000000000000"
+            "default": "0x0000000000000000000000000000000000000000",
+            "x-go-type-skip-optional-pointer": true
           },
           "makingAmount": {
             "type": "string",
-            "description": "Order maker's token amount"
+            "description": "Order maker's token amount",
+            "x-go-type-skip-optional-pointer": true
           },
           "takingAmount": {
             "type": "string",
-            "description": "Order taker's token amount"
+            "description": "Order taker's token amount",
+            "x-go-type-skip-optional-pointer": true
           },
           "salt": {
             "type": "string",
-            "description": "Some unique value. It is necessary to be able to create limit orders with the same parameters (so that they have a different hash)"
+            "description": "Some unique value. It is necessary to be able to create limit orders with the same parameters (so that they have a different hash)",
+            "x-go-type-skip-optional-pointer": true
           },
           "offsets": {
             "type": "string",
             "description": "An interaction call data. ABI encoded set of makerAssetData, takerAssetData, getMakingAmount, getTakingAmount, predicate, permit, preInteraction, postInteraction",
-            "default": "0x"
+            "default": "0x",
+            "x-go-type-skip-optional-pointer": true
           },
           "interactions": {
             "type": "string",
             "description": "Merged offsets of each field in interactions",
-            "default": "0"
+            "default": "0",
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": [
@@ -308,15 +397,21 @@
         "properties": {
           "orderHash": {
             "type": "string",
-            "description": "Hash of the limit order typed data"
+            "description": "Hash of the limit order typed data",
+            "x-go-type-skip-optional-pointer": true
           },
           "signature": {
             "type": "string",
-            "description": "Signature of the limit order typed data (using signTypedData_v4)"
+            "description": "Signature of the limit order typed data (using signTypedData_v4)",
+            "x-go-type-skip-optional-pointer": true
           },
           "data": {
             "description": "Limit order data",
-            "allOf": [{ "$ref": "#/components/schemas/LimitOrderV3Data" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LimitOrderV3Data"
+              }
+            ]
           }
         },
         "required": ["orderHash", "signature", "data"]

--- a/golang/swagger-static/swap-swagger.json
+++ b/golang/swagger-static/swap-swagger.json
@@ -39,7 +39,8 @@
             "in": "query",
             "description": "All supported liquidity sources by default",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -50,7 +51,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 3,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -59,7 +61,8 @@
             "in": "query",
             "description": "Network price per gas in wei. By default fast network gas price",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -69,7 +72,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 2,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -79,7 +83,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 50,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -89,7 +94,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 10,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -99,7 +105,8 @@
             "schema": {
               "minimum": 100000,
               "maximum": 11500000,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -108,7 +115,8 @@
             "in": "query",
             "description": "Return fromToken and toToken info in response",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -117,7 +125,8 @@
             "in": "query",
             "description": "Return used swap protocols in response",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -126,7 +135,8 @@
             "in": "query",
             "description": "Return approximated gas in response",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -136,7 +146,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 5,
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           }
         ],
@@ -224,7 +235,8 @@
             "in": "query",
             "description": "All supported liquidity sources by default",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -235,7 +247,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 3,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -244,7 +257,8 @@
             "in": "query",
             "description": "Network price per gas in wei. By default fast network gas price",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -254,7 +268,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 2,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -264,7 +279,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 50,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -274,7 +290,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 10,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -284,7 +301,8 @@
             "schema": {
               "minimum": 100000,
               "maximum": 11500000,
-              "type": "number"
+              "type": "number",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -293,7 +311,8 @@
             "in": "query",
             "description": "Return fromToken and toToken info in response",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -302,7 +321,8 @@
             "in": "query",
             "description": "Return used swap protocols in response",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -311,7 +331,8 @@
             "in": "query",
             "description": "Return approximated gas in response",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -321,7 +342,8 @@
             "schema": {
               "minimum": 0,
               "maximum": 5,
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -330,7 +352,8 @@
             "in": "query",
             "description": "https://eips.ethereum.org/EIPS/eip-2612",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -339,7 +362,8 @@
             "in": "query",
             "description": "This address will receive funds after the swap. By default same address as \"from\" param",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -347,7 +371,8 @@
             "required": false,
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -356,7 +381,8 @@
             "in": "query",
             "description": "By default set to false",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": true
             }
           },
           {
@@ -365,7 +391,8 @@
             "in": "query",
             "description": "Enable this flag to disable onchain simulation",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": true
             }
           }
         ],
@@ -436,7 +463,8 @@
             "example": "100000000000",
             "description": "The number of tokens that the 1inch Router is allowed to swap.If not specified, it will be allowed to spend an infinite amount of tokens.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           }
         ],
@@ -553,7 +581,8 @@
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/TokenInfo"
-            }
+            },
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["tokens"]
@@ -563,41 +592,50 @@
         "properties": {
           "address": {
             "type": "string",
-            "example": "0x111111111117dc0aa78b770fa6a738034120c302"
+            "example": "0x111111111117dc0aa78b770fa6a738034120c302",
+            "x-go-type-skip-optional-pointer": true
           },
           "symbol": {
             "type": "string",
-            "example": "1INCH"
+            "example": "1INCH",
+            "x-go-type-skip-optional-pointer": true
           },
           "name": {
             "type": "string",
-            "example": "1INCH Token"
+            "example": "1INCH Token",
+            "x-go-type-skip-optional-pointer": true
           },
           "decimals": {
             "type": "number",
-            "example": 18
+            "example": 18,
+            "x-go-type-skip-optional-pointer": true
           },
           "logoURI": {
             "type": "string",
-            "example": "https://tokens.1inch.io/0x111111111117dc0aa78b770fa6a738034120c302.png"
+            "example": "https://tokens.1inch.io/0x111111111117dc0aa78b770fa6a738034120c302.png",
+            "x-go-type-skip-optional-pointer": true
           },
           "domainVersion": {
-            "type": "string"
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
           },
           "eip2612": {
             "type": "boolean",
-            "example": true
+            "example": true,
+            "x-go-type-skip-optional-pointer": true
           },
           "isFoT": {
             "type": "boolean",
-            "example": false
+            "example": false,
+            "x-go-type-skip-optional-pointer": true
           },
           "tags": {
             "example": ["tokens"],
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["address", "symbol", "name", "decimals", "logoURI"]
@@ -624,7 +662,8 @@
           "toAmount": {
             "type": "string",
             "description": "Expected amount of destination token",
-            "example": "62131879850006790961"
+            "example": "62131879850006790961",
+            "x-go-type-skip-optional-pointer": true
           },
           "protocols": {
             "type": "array",
@@ -637,12 +676,14 @@
                   "$ref": "#/components/schemas/SelectedProtocol"
                 }
               }
-            }
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "gas": {
             "type": "number",
             "description": "Estimated gas",
-            "example": 100000
+            "example": 100000,
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["toAmount"]
@@ -651,10 +692,12 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": "string"
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
           },
           "value": {
-            "type": "string"
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["type", "value"]
@@ -665,30 +708,35 @@
           "error": {
             "type": "string",
             "description": "Error code description",
-            "example": "Bad Request"
+            "example": "Bad Request",
+            "x-go-type-skip-optional-pointer": true
           },
           "description": {
             "type": "string",
             "description": "Error description",
-            "example": "insufficient liquidity"
+            "example": "insufficient liquidity",
+            "x-go-type-skip-optional-pointer": true
           },
           "statusCode": {
             "type": "number",
             "description": "HTTP code",
             "enum": [400, 500],
-            "example": 400
+            "example": 400,
+            "x-go-type-skip-optional-pointer": true
           },
           "requestId": {
             "type": "string",
             "description": "Request id",
-            "example": "2a92c18a-5c20-4f0d-a0da-e8b5b3602ad6"
+            "example": "2a92c18a-5c20-4f0d-a0da-e8b5b3602ad6",
+            "x-go-type-skip-optional-pointer": true
           },
           "meta": {
             "description": "Meta information",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/HttpExceptionMeta"
-            }
+            },
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["error", "description", "statusCode", "requestId", "meta"]
@@ -698,27 +746,33 @@
         "properties": {
           "from": {
             "type": "string",
-            "example": "0x1111111111111111111111111111111111111111"
+            "example": "0x1111111111111111111111111111111111111111",
+            "x-go-type-skip-optional-pointer": true
           },
           "to": {
             "type": "string",
-            "example": "0x1111111254eeb25477b68fb85ed929f73a960582"
+            "example": "0x1111111254eeb25477b68fb85ed929f73a960582",
+            "x-go-type-skip-optional-pointer": true
           },
           "data": {
             "type": "string",
-            "example": "0x0502b1c50000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002386f26fc10000000000000000000000000000000000000000000000000003556e53186804ca3e0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000180000000000000003b6d034026aad2da94c59524ac0d93f6d6cbf9071d7086f2"
+            "example": "0x0502b1c50000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002386f26fc10000000000000000000000000000000000000000000000000003556e53186804ca3e0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000180000000000000003b6d034026aad2da94c59524ac0d93f6d6cbf9071d7086f2",
+            "x-go-type-skip-optional-pointer": true
           },
           "value": {
             "type": "string",
-            "example": "10000000000000000"
+            "example": "10000000000000000",
+            "x-go-type-skip-optional-pointer": true
           },
           "gasPrice": {
             "type": "string",
-            "example": "6994090150"
+            "example": "6994090150",
+            "x-go-type-skip-optional-pointer": true
           },
           "gas": {
             "type": "number",
-            "example": 121363
+            "example": 121363,
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["from", "to", "data", "value", "gasPrice", "gas"]
@@ -745,7 +799,8 @@
           "toAmount": {
             "type": "string",
             "description": "Expected amount of destination token",
-            "example": "62131879850006790961"
+            "example": "62131879850006790961",
+            "x-go-type-skip-optional-pointer": true
           },
           "protocols": {
             "type": "array",
@@ -758,7 +813,8 @@
                   "$ref": "#/components/schemas/SelectedProtocol"
                 }
               }
-            }
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "tx": {
             "description": "Transaction object",
@@ -777,30 +833,35 @@
           "error": {
             "type": "string",
             "description": "Error code description",
-            "example": "Bad Request"
+            "example": "Bad Request",
+            "x-go-type-skip-optional-pointer": true
           },
           "description": {
             "type": "string",
             "description": "Error description",
-            "example": "cannot estimate"
+            "example": "cannot estimate",
+            "x-go-type-skip-optional-pointer": true
           },
           "statusCode": {
             "type": "number",
             "description": "HTTP code",
             "enum": [400, 500],
-            "example": 400
+            "example": 400,
+            "x-go-type-skip-optional-pointer": true
           },
           "requestId": {
             "type": "string",
             "description": "Request id",
-            "example": "2a92c18a-5c20-4f0d-a0da-e8b5b3602ad6"
+            "example": "2a92c18a-5c20-4f0d-a0da-e8b5b3602ad6",
+            "x-go-type-skip-optional-pointer": true
           },
           "meta": {
             "description": "Meta information",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/HttpExceptionMeta"
-            }
+            },
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["error", "description", "statusCode", "requestId", "meta"]
@@ -811,7 +872,8 @@
           "address": {
             "type": "string",
             "description": "Address of the 1inch Router that is trusted to spend funds for the swap",
-            "example": "0x1111111254eeb25477b68fb85ed929f73a960582"
+            "example": "0x1111111254eeb25477b68fb85ed929f73a960582",
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["address"]
@@ -822,22 +884,26 @@
           "data": {
             "type": "string",
             "description": "The encoded data to call the approve method on the swapped token contract",
-            "example": "0x095ea7b30000000000000000000000001111111254eeb25477b68fb85ed929f73a960582ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            "example": "0x095ea7b30000000000000000000000001111111254eeb25477b68fb85ed929f73a960582ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "x-go-type-skip-optional-pointer": true
           },
           "gasPrice": {
             "type": "string",
             "description": "Network high gas price in wei",
-            "example": "1000000000"
+            "example": "1000000000",
+            "x-go-type-skip-optional-pointer": true
           },
           "to": {
             "type": "string",
             "description": "Token address that will be allowed to exchange through 1inch Router",
-            "example": "0x111111111117dc0aa78b770fa6a738034120c302"
+            "example": "0x111111111117dc0aa78b770fa6a738034120c302",
+            "x-go-type-skip-optional-pointer": true
           },
           "value": {
             "type": "string",
             "description": "Native token value in wei (for approve is always 0)",
-            "example": "0"
+            "example": "0",
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["data", "gasPrice", "to", "value"]
@@ -848,7 +914,8 @@
           "allowance": {
             "type": "string",
             "description": "Allowance amount",
-            "example": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            "example": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["allowance"]
@@ -858,19 +925,23 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Protocol id"
+            "description": "Protocol id",
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string",
-            "description": "Protocol title"
+            "description": "Protocol title",
+            "x-go-type-skip-optional-pointer": true
           },
           "img": {
             "type": "string",
-            "description": "Protocol logo image"
+            "description": "Protocol logo image",
+            "x-go-type-skip-optional-pointer": true
           },
           "img_color": {
             "type": "string",
-            "description": "Protocol logo image in color"
+            "description": "Protocol logo image in color",
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["id", "title", "img", "img_color"]
@@ -883,7 +954,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ProtocolImage"
-            }
+            },
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["protocols"]
@@ -894,22 +966,26 @@
           "name": {
             "type": "string",
             "description": "Protocol id",
-            "example": "UNISWAP_V3"
+            "example": "UNISWAP_V3",
+            "x-go-type-skip-optional-pointer": true
           },
           "part": {
             "type": "number",
             "description": "Protocol share",
-            "example": 100
+            "example": 100,
+            "x-go-type-skip-optional-pointer": true
           },
           "fromTokenAddress": {
             "type": "string",
             "description": "Source token to swap on protocol",
-            "example": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+            "example": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "x-go-type-skip-optional-pointer": true
           },
           "toTokenAddress": {
             "type": "string",
             "description": "Destination token to swap on protocol",
-            "example": "0x111111111117dc0aa78b770fa6a738034120c302"
+            "example": "0x111111111117dc0aa78b770fa6a738034120c302",
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["name", "part", "fromTokenAddress", "toTokenAddress"]

--- a/golang/swagger-static/tokenprices-swagger.json
+++ b/golang/swagger-static/tokenprices-swagger.json
@@ -60,7 +60,8 @@
                 "VND",
                 "ZAR"
               ],
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           }
         ],
@@ -243,7 +244,8 @@
                 "VND",
                 "ZAR"
               ],
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": true
             }
           }
         ],
@@ -319,7 +321,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["codes"]
@@ -332,12 +335,14 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "currency": {
             "type": "string",
             "enum": ["USD"],
-            "description": "If no currency provided, then price returned in native Wei"
+            "description": "If no currency provided, then price returned in native Wei",
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": ["tokens"]


### PR DESCRIPTION
`oapi-codegen` is the tool used to convert an OpenAPI spec file into Golang structs. By default, it sets optional parameter types to pointers, but this leads to clunky configuration for the user. This PR updates the swagger files in-place to append  `oapi-codegen`'s custom field `x-go-type-skip-optional-pointer` to all parameters and schemas in the swagger spec. 

If possible, this should be done in a more native way (potentially using `oapi-codegen`'s [template framework](https://github.com/deepmap/oapi-codegen?tab=readme-ov-file#making-changes-to-code-generation)). The current approach uses jQuery to update the swagger spec and could lead to unexpected behavior in at least two scenarios:

1. Response objects no longer have pointers. This means lots of "zero" values will come back on these structs when parsing API responses. This will lead to clunky response objects at best and confusing responses at worst.
2. The jQuery command is a blanket update to the swagger files and likely does not cover all edge cases. We will need to monitor this as more services are added/updated