### PR TITLE
Add strongly typed errors for fail-on-no-approval scenario

### DIFF
--- a/golang/client/orderbook.go
+++ b/golang/client/orderbook.go
@@ -101,7 +101,7 @@ func (s *OrderbookService) CreateOrder(ctx context.Context, params orderbook.Cre
 		if allowance.Cmp(makingAmountBig) <= 0 {
 
 			if params.FailIfApprovalIsNeeded {
-				return nil, nil, errors.New("1inch router does not have approval for this token")
+				return nil, nil, orderbook.ErrorFailWhenApprovalIsNeeded
 			}
 
 			if !params.SkipWarnings {

--- a/golang/client/orderbook/errors.go
+++ b/golang/client/orderbook/errors.go
@@ -1,0 +1,5 @@
+package orderbook
+
+import "errors"
+
+var ErrorFailWhenApprovalIsNeeded = errors.New("1inch router does not have approval")

--- a/golang/client/orderbook_integration_test.go
+++ b/golang/client/orderbook_integration_test.go
@@ -50,7 +50,7 @@ func TestCreateOrderIntegration(t *testing.T) {
 				SkipWarnings:           true,
 				FailIfApprovalIsNeeded: true,
 			},
-			expectedError: "1inch router does not have approval",
+			expectedError: orderbook.ErrorFailWhenApprovalIsNeeded.Error(),
 		},
 	}
 

--- a/golang/client/orderbook_integration_test.go
+++ b/golang/client/orderbook_integration_test.go
@@ -74,7 +74,7 @@ func TestCreateOrderIntegration(t *testing.T) {
 
 			orderResponse, resp, err := c.Orderbook.CreateOrder(context.Background(), tc.orderRequest)
 			if tc.expectedError != "" {
-				require.Contains(t, err.Error(), tc.expectedError)
+				require.Equal(t, err.Error(), tc.expectedError)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, 201, resp.StatusCode)


### PR DESCRIPTION
When the integrator wants orderbook creation requests to fail when the 1inch router does not have enough allowance, we now return a strongly typed error message to make the logic cleaner.